### PR TITLE
Método para desativar anúncio

### DIFF
--- a/Backend/Balcao.API/Controllers/AnuncioController.cs
+++ b/Backend/Balcao.API/Controllers/AnuncioController.cs
@@ -157,8 +157,6 @@ namespace Balcao.API.Controllers
         [Route("{id}/Desativar")]
         public IActionResult Desativar(int id, AnuncioDTO anuncioDTO)
         {
-            throw new NotImplementedException();
-
             var anuncio = _anuncioRepository.Get(id);
 
             if (anuncio == null)
@@ -167,7 +165,9 @@ namespace Balcao.API.Controllers
             if (!TokenService.EhAdmin(User) && !TokenService.EhProprietario(anuncio.Proprietario, User))
                 return Unauthorized("Você não tem permissão para desativar este anúncio!");
 
-            _anuncioRepository.Delete(anuncio);
+            anuncio.Desativar();
+
+            _anuncioRepository.Update(anuncio);
             return Ok(anuncio.ToJson());
         }
 
@@ -225,6 +225,12 @@ namespace Balcao.API.Controllers
 
             if (anuncio == null)
                 return NotFound("Anúncio não encontrado!");
+
+            if (!anuncio.Ativo)
+                return BadRequest("Anúncio não está mais ativo!");
+
+            if (anuncio.Quantidade < quantidade)
+                return BadRequest("Quantidade solicitada maior que a quantidade disponível!");
 
             Usuario comprador = _usuarioRepository.Get(idComprador);
 

--- a/Backend/Balcao.Domain/Entities/Anuncio.cs
+++ b/Backend/Balcao.Domain/Entities/Anuncio.cs
@@ -46,10 +46,26 @@
             Proprietario.Avaliar(nota);
         }
 
-        public void FecharCompra(int quantidade)
+        public void AtualizarQuantidade(int quantidade)
         {
             if (!EhServico())
+            {
                 Quantidade -= quantidade;
+                if (Quantidade <= 0)
+                {
+                    Desativar();
+                }
+            }
+        }
+
+        public void Desativar()
+        {
+            Ativo = false;
+            Compras.ForEach(c =>
+            {
+                if (c.Status < StatusCompra.PRODUTO_RECEBIDO)
+                    c.Status = StatusCompra.CANCELADO;
+            });
         }
 
         public object ToJson()

--- a/Backend/Balcao.Domain/Entities/Compra.cs
+++ b/Backend/Balcao.Domain/Entities/Compra.cs
@@ -28,6 +28,7 @@
         public void ConfirmarRecebimento()
         {
             Status = StatusCompra.PRODUTO_RECEBIDO;
+            Assunto.AtualizarQuantidade(Quantidade);
         }
 
         public void AvaliarVendedor(float nota)
@@ -45,7 +46,6 @@
 
         public void FecharCompra()
         {
-            Assunto.FecharCompra(Quantidade);
             Status = StatusCompra.CONCLUIDO;
         }
 


### PR DESCRIPTION
Rota para desativar anúncio a qualquer momento, sendo proprietário ou admin - Controle de quantidade do produto e desativação automático ao esgotar\n\n- Cancela automaticamente todas as Compras que o status está anterior a produto recebido